### PR TITLE
display series duration and lift count on lcd

### DIFF
--- a/machine/distance_sensor.ino
+++ b/machine/distance_sensor.ino
@@ -21,8 +21,6 @@ TimerHandle_t secondsTimerHandle = NULL;
 EventGroupHandle_t updateLcdEventGroup = NULL;
 
 void finishCurrentSet(TimerHandle_t xTimer) {
-  Serial.printf("Set #%d finished: %d reps\n",
-                numberOfSets, numberOfRepetitions);
   numberOfRepetitions = 0;
   numberOfSets++;
   seconds = 0;
@@ -31,7 +29,6 @@ void finishCurrentSet(TimerHandle_t xTimer) {
 }
 
 void finishCurrentExercise(TimerHandle_t xTimer) {
-  Serial.printf("Exercise finished: %d sets\n", numberOfSets);
   numberOfRepetitions = 0;
   numberOfSets = 0;
   seconds = 0;
@@ -55,10 +52,8 @@ void countNumberOfRepetitions(void *pvParameters) {
 
     int distance = measureWeightDistance();
 
-    if (distance <= DISTANCE_THRESHOLD_PUSH
-        && !isStillLifted) {
+    if (distance <= DISTANCE_THRESHOLD_PUSH && !isStillLifted) {
       if (numberOfRepetitions == 1) {
-        Serial.println("Starting seconds timer");
         xTimerReset(secondsTimerHandle, portMAX_DELAY);
       }
       isResting = false;
@@ -75,7 +70,6 @@ void countNumberOfRepetitions(void *pvParameters) {
 
 void incrementSecond(TimerHandle_t xTimer) {
   seconds++;
-  Serial.println(seconds);
   xEventGroupSetBits(updateLcdEventGroup, BIT_UPDATE_DISPLAY);
 }
 

--- a/machine/distance_sensor.ino
+++ b/machine/distance_sensor.ino
@@ -1,27 +1,42 @@
-#define PIN_TRIG    25
-#define PIN_ECHO    32
-#define SOUND_SPEED 0.034
-#define DISTANCE_THRESHOLD 350
-#define TIMEOUT_CURRENT_SET_MS 10000
-#define TIMEOUT_CURRENT_EXERCISE_MS 120000
+#define PIN_TRIG                    25
+#define PIN_ECHO                    32
+#define SOUND_SPEED                 0.034
+#define DISTANCE_THRESHOLD_PUSH     350
+#define DISTANCE_THRESHOLD_RELEASE  380
+#define TIMEOUT_CURRENT_SET_MS      10000
+#define TIMEOUT_CURRENT_EXERCISE_MS 30000 //fixme later
+
+#define BIT_UPDATE_DISPLAY  ( 1 << 0 )
+#define BIT_WAITING_RFID    ( 1 << 1 )
 
 uint8_t numberOfRepetitions = 0;
-uint8_t numberOfSets = 0;
+uint8_t numberOfSets        = 0;
+uint8_t seconds             = 0;
+bool    isResting           = false;
 
-TimerHandle_t repTimerHandle = NULL;
-TimerHandle_t setTimerHandle = NULL;
+TimerHandle_t repTimerHandle     = NULL;
+TimerHandle_t setTimerHandle     = NULL;
+TimerHandle_t secondsTimerHandle = NULL;
+
+EventGroupHandle_t updateLcdEventGroup = NULL;
 
 void finishCurrentSet(TimerHandle_t xTimer) {
   Serial.printf("Set #%d finished: %d reps\n",
-    numberOfSets, numberOfRepetitions);
+                numberOfSets, numberOfRepetitions);
   numberOfRepetitions = 0;
   numberOfSets++;
+  seconds = 0;
+  isResting = true;
+  xEventGroupSetBits(updateLcdEventGroup, BIT_UPDATE_DISPLAY);
 }
 
 void finishCurrentExercise(TimerHandle_t xTimer) {
   Serial.printf("Exercise finished: %d sets\n", numberOfSets);
   numberOfRepetitions = 0;
   numberOfSets = 0;
+  seconds = 0;
+  xEventGroupSetBits(updateLcdEventGroup, BIT_WAITING_RFID);
+  xTimerStop(secondsTimerHandle, portMAX_DELAY);
 }
 
 int measureWeightDistance() {
@@ -35,19 +50,32 @@ int measureWeightDistance() {
 
 void countNumberOfRepetitions(void *pvParameters) {
   bool isStillLifted = false;
+
   while (true) {
-    
+
     int distance = measureWeightDistance();
-    
-    if (distance <= DISTANCE_THRESHOLD && !isStillLifted) {
+
+    if (distance <= DISTANCE_THRESHOLD_PUSH
+        && !isStillLifted) {
+      if (numberOfRepetitions == 1) {
+        Serial.println("Starting seconds timer");
+        xTimerReset(secondsTimerHandle, portMAX_DELAY);
+      }
+      isResting = false;
       xTimerReset(repTimerHandle, portMAX_DELAY);
       xTimerReset(setTimerHandle, portMAX_DELAY);
       numberOfRepetitions++;
+      xEventGroupSetBits(updateLcdEventGroup, BIT_UPDATE_DISPLAY);
       isStillLifted = true;
-      Serial.println(numberOfRepetitions);
-    } else if (distance > DISTANCE_THRESHOLD) {
+    } else if (distance > DISTANCE_THRESHOLD_RELEASE) {
       isStillLifted = false;
     }
   }
+}
+
+void incrementSecond(TimerHandle_t xTimer) {
+  seconds++;
+  Serial.println(seconds);
+  xEventGroupSetBits(updateLcdEventGroup, BIT_UPDATE_DISPLAY);
 }
 

--- a/machine/lcd.ino
+++ b/machine/lcd.ino
@@ -1,0 +1,71 @@
+// include the library code:
+#include <LiquidCrystal.h>
+
+// initialize the library with the numbers of the interface pins
+LiquidCrystal lcd(19, 23, 18, 17, 16, 15);
+
+
+
+void displayStuffOnLCD(void *pvParameters) {
+
+  while (true) {
+    EventBits_t uxBits = xEventGroupWaitBits(
+                           updateLcdEventGroup,   /* The event group being tested. */
+                           BIT_UPDATE_DISPLAY | BIT_WAITING_RFID, /* The bits within the event group to wait for. */
+                           pdTRUE,        /* bits cleared before returning. */
+                           pdFALSE,       /* Don't wait for both bits, either bit will do. */
+                           portMAX_DELAY
+                         );
+    lcd.clear();
+    if ( ( uxBits & BIT_UPDATE_DISPLAY ) != 0 ) {
+      displayRepsAndSets();
+      if (isResting) {
+        displayResting();
+      } else {
+        displayWorkOut();
+      }
+      displayTime();
+    } else if ( ( uxBits & BIT_WAITING_RFID ) != 0 ) {
+      displayWaitingRfid();
+    }
+  }
+}
+
+void displayRepsAndSets() {
+  lcd.setCursor(0, 0);
+  lcd.print("Sets:");
+  lcd.print(numberOfSets);
+  lcd.print("|");
+  lcd.print("Reps:");
+  lcd.print(numberOfRepetitions);
+}
+
+void displayTime() {
+  lcd.setCursor(11, 1);
+  uint8_t minutes = seconds / 60;
+  lcd.print("0");
+  lcd.print(minutes);
+  lcd.print(":");
+  if (seconds < 10) {
+    lcd.print("0");
+  }
+  lcd.print(seconds);
+}
+
+void displayResting() {
+  lcd.setCursor(0, 1);
+  lcd.print("Resting:");
+}
+
+void displayWorkOut() {
+  lcd.setCursor(0, 1);
+  lcd.print("Work out:");
+}
+
+void displayWaitingRfid() {
+  lcd.setCursor(0, 0);
+  lcd.print("Approach card");
+  lcd.setCursor(0, 1);
+  lcd.print("to start");
+}
+

--- a/machine/main.ino
+++ b/machine/main.ino
@@ -1,6 +1,5 @@
 void setup() {
   Serial.begin(115200);
-  Serial.println("Hello, ESP32!");
   pinMode(PIN_TRIG, OUTPUT);
   pinMode(PIN_ECHO, INPUT);
 

--- a/machine/main.ino
+++ b/machine/main.ino
@@ -4,6 +4,10 @@ void setup() {
   pinMode(PIN_TRIG, OUTPUT);
   pinMode(PIN_ECHO, INPUT);
 
+  // set up the LCD's number of columns and rows:
+  lcd.begin(16, 2);
+  updateLcdEventGroup = xEventGroupCreate();
+
   repTimerHandle = xTimerCreate(
     "repTimer",
     pdMS_TO_TICKS(TIMEOUT_CURRENT_SET_MS),
@@ -20,6 +24,14 @@ void setup() {
     finishCurrentExercise
   );
 
+  secondsTimerHandle = xTimerCreate(
+    "secondsTimer",
+    pdMS_TO_TICKS(1000),
+    pdTRUE,
+    (void *) 0,
+    incrementSecond
+  );
+
   xTaskCreate(
     countNumberOfRepetitions,
     "countReps",
@@ -28,6 +40,17 @@ void setup() {
     1,
     NULL
   );
+
+  xTaskCreate(
+    displayStuffOnLCD,
+    "displayStuffOnLCD",
+    4094,
+    NULL,
+    1,
+    NULL
+  );
+
+  displayWaitingRfid();
 }
 
 void loop() {


### PR DESCRIPTION
This pull request includes significant updates to the `machine` module, primarily focusing on enhancing the distance sensor functionality and integrating an LCD display for user feedback. The most important changes are outlined below:

### Enhancements to distance sensor functionality:

* Updated distance thresholds to differentiate between push and release actions, and added new constants for display updates and RFID waiting states in `machine/distance_sensor.ino`.
* Modified the `countNumberOfRepetitions` function to reset the timer and update the display when a repetition is detected.

### Integration of LCD display:

* Added the `LiquidCrystal` library and implemented functions to display sets, repetitions, workout/resting status, and time on the LCD.
* Created a new task to handle LCD updates based on event group bits in `machine/lcd.ino`.

### Main setup adjustments:

* Initialized the LCD and created event groups and timers for updating the display and tracking seconds in `machine/main.ino`. [[1]](diffhunk://#diff-bfd3658d67513079693117368faac94fc7fe8ed4e440e4cbb9266ff2f96698cdL3-R9) [[2]](diffhunk://#diff-bfd3658d67513079693117368faac94fc7fe8ed4e440e4cbb9266ff2f96698cdR26-R33)
* Added a new task to continuously update the LCD display and display the waiting RFID message at startup.