### PR TITLE
16 create endpoint to get exercises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 # env file
 .env
 .idea
+
+# outputs
+bin

--- a/workout-logs/Makefile
+++ b/workout-logs/Makefile
@@ -21,6 +21,10 @@ build:
 	mkdir -p $(BUILD_DIR)
 	go build -o $(BUILD_DIR)/$(APP_NAME) $(ENTRY)
 
+.PHONY: docs
+docs:
+	swag init -g internal/adapter/http.go
+
 .PHONY: debug
 debug:
 	if [ ! -d "$(BUILD_DIR)" ]; then \

--- a/workout-logs/cmd/api/main.go
+++ b/workout-logs/cmd/api/main.go
@@ -15,12 +15,12 @@ import (
 	"github.com/swaggo/http-swagger"
 )
 
-// @title Smart-Gym API
-// @version 1.0
-// @description This is the strongest server ever.
+//	@title			Smart-Gym API
+//	@version		1.0
+//	@description	This is the strongest server ever.
 
-// @BasePath /api/v1
-// @accept json
+// @BasePath	/api/v1
+// @accept		json
 func main() {
 	setUpLogger()
 	mongo.GetConnection()

--- a/workout-logs/docs/docs.go
+++ b/workout-logs/docs/docs.go
@@ -5,9 +5,6 @@ import "github.com/swaggo/swag"
 
 const docTemplate = `{
     "schemes": {{ marshal .Schemes }},
-    "consumes": [
-        "application/json"
-    ],
     "swagger": "2.0",
     "info": {
         "description": "{{escape .Description}}",
@@ -42,6 +39,56 @@ const docTemplate = `{
                                 "$ref": "#/definitions/exercise.ExerciseRecord"
                             }
                         }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/users/{user_id}/origins/{origin_id}/exercises": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "Get exercises based on query parameters",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Start time in Unix timestamp",
+                        "name": "started_at",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Finish time in Unix timestamp",
+                        "name": "finished_at",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Origin ID",
+                        "name": "origin_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -100,12 +147,12 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
+	Version:          "",
 	Host:             "",
-	BasePath:         "/api/v1",
+	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "Smart-Gym API",
-	Description:      "This is the strongest server ever.",
+	Title:            "",
+	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/workout-logs/docs/swagger.json
+++ b/workout-logs/docs/swagger.json
@@ -1,15 +1,8 @@
 {
-    "consumes": [
-        "application/json"
-    ],
     "swagger": "2.0",
     "info": {
-        "description": "This is the strongest server ever.",
-        "title": "Smart-Gym API",
-        "contact": {},
-        "version": "1.0"
+        "contact": {}
     },
-    "basePath": "/api/v1",
     "paths": {
         "/exercises": {
             "post": {
@@ -35,6 +28,56 @@
                                 "$ref": "#/definitions/exercise.ExerciseRecord"
                             }
                         }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/users/{user_id}/origins/{origin_id}/exercises": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "Get exercises based on query parameters",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Start time in Unix timestamp",
+                        "name": "started_at",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Finish time in Unix timestamp",
+                        "name": "finished_at",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Origin ID",
+                        "name": "origin_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "User ID",
+                        "name": "user_id",
+                        "in": "path",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/workout-logs/docs/swagger.yaml
+++ b/workout-logs/docs/swagger.yaml
@@ -1,6 +1,3 @@
-basePath: /api/v1
-consumes:
-- application/json
 definitions:
   exercise.ExerciseData:
     properties:
@@ -32,9 +29,6 @@ definitions:
     type: object
 info:
   contact: {}
-  description: This is the strongest server ever.
-  title: Smart-Gym API
-  version: "1.0"
 paths:
   /exercises:
     post:
@@ -56,6 +50,40 @@ paths:
           description: OK
           schema: {}
       summary: Create a couple of exercises
+      tags:
+      - exercises
+  /users/{user_id}/origins/{origin_id}/exercises:
+    get:
+      consumes:
+      - application/json
+      parameters:
+      - description: Start time in Unix timestamp
+        in: query
+        name: started_at
+        required: true
+        type: integer
+      - description: Finish time in Unix timestamp
+        in: query
+        name: finished_at
+        required: true
+        type: integer
+      - description: Origin ID
+        in: path
+        name: origin_id
+        required: true
+        type: string
+      - description: User ID
+        in: path
+        name: user_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema: {}
+      summary: Get exercises based on query parameters
       tags:
       - exercises
 swagger: "2.0"

--- a/workout-logs/internal/adapter/http.go
+++ b/workout-logs/internal/adapter/http.go
@@ -10,7 +10,7 @@ import (
 func MakeAppRouter() chi.Router {
 	appRouter := chi.NewRouter()
 
-	appRouter.Post("/exercises", u.MakeRouteHandler(exercise.CreateExerciseHandler))
-
+	//appRouter.Post("/exercises", u.MakeRouteHandler(exercise.CreateExerciseHandler))
+	appRouter.Get("/users/{user_id}/origins/{origin_id}/exercises", u.MakeRouteHandler(exercise.GetExercisesHandler))
 	return appRouter
 }

--- a/workout-logs/internal/adapter/http.go
+++ b/workout-logs/internal/adapter/http.go
@@ -10,7 +10,7 @@ import (
 func MakeAppRouter() chi.Router {
 	appRouter := chi.NewRouter()
 
-	//appRouter.Post("/exercises", u.MakeRouteHandler(exercise.CreateExerciseHandler))
+	appRouter.Post("/exercises", u.MakeRouteHandler(exercise.CreateExerciseHandler))
 	appRouter.Get("/users/{user_id}/origins/{origin_id}/exercises", u.MakeRouteHandler(exercise.GetExercisesHandler))
 	return appRouter
 }

--- a/workout-logs/internal/core/exercise/adapter/http.go
+++ b/workout-logs/internal/core/exercise/adapter/http.go
@@ -6,7 +6,13 @@ import (
 	"cloud-gym/internal/mongo"
 	utils "cloud-gym/pkg"
 	s "cloud-gym/pkg/service"
+	"errors"
+	"github.com/go-chi/chi/v5"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"log/slog"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 // Create Exercises Handler
@@ -18,26 +24,77 @@ import (
 //	@Param			exercises body []exercise.ExerciseRecord true "Exercises"
 //	@Success		200	{object}	any
 //	@Router			/exercises [post]
-func CreateExerciseHandler(w http.ResponseWriter, r *http.Request) error {
-	var input []exercise.ExerciseRecord
-	if err := utils.ParseJson(r, &input); err != nil {
+//func CreateExerciseHandler(w http.ResponseWriter, r *http.Request) error {
+//	var input []exercise.ExerciseRecord
+//	if err := utils.ParseJson(r, &input); err != nil {
+//		return s.NewServiceError(400, err)
+//	}
+//
+//	for _, data := range input {
+//		if err := utils.ValidateJsonStruct(&data); err != nil {
+//			return s.NewServiceError(400, err)
+//		}
+//	}
+//
+//	useCase := usecases.NewCreateExercises(getExerciseRepository())
+//
+//	result, err := useCase.Execute(input)
+//	if err != nil {
+//		return err
+//	}
+//
+//	utils.WriteJSON(w, http.StatusCreated, result)
+//
+//	return nil
+//}
+
+// GetExercisesHandler handles fetching exercises based on query parameters.
+//
+// @Summary      Get exercises based on query parameters
+// @Tags         exercises
+// @Accept       json
+// @Produce      json
+// @Param        started_at query uint64 true "Start time"
+// @Param        finished_at query uint64 true "Finish time"
+// @Param        origin_id query string true "Origin ID"
+// @Param        user_id query uint64 true "User ID"
+// @Success      200 {object} any
+func GetExercisesHandler(w http.ResponseWriter, r *http.Request) error {
+	startedAt, err := strconv.ParseInt(r.URL.Query().Get("started_at"), 10, 64)
+	finishedAt, err := strconv.ParseInt(r.URL.Query().Get("finished_at"), 10, 64)
+
+	if err != nil {
 		return s.NewServiceError(400, err)
 	}
 
-	for _, data := range input {
-		if err := utils.ValidateJsonStruct(&data); err != nil {
-			return s.NewServiceError(400, err)
-		}
+	_userId := chi.URLParam(r, "user_id")
+	userId, err := strconv.ParseUint(_userId, 10, 64)
+	if err != nil {
+		return s.NewServiceError(400, err)
 	}
 
-	useCase := usecases.NewCreateExercises(getExerciseRepository())
+	originId := chi.URLParam(r, "origin_id")
+	if originId == "" {
+		return s.NewServiceError(400, errors.New("origin_id or user_id is empty on path parameter"))
+	}
 
+	useCase := usecases.NewGetExercises(getExerciseRepository())
+
+	input := usecases.InputGetExercises{
+		StartedAt:  primitive.NewDateTimeFromTime(time.Unix(startedAt, 0)),
+		FinishedAt: primitive.NewDateTimeFromTime(time.Unix(finishedAt, 0)),
+		OriginId:   originId,
+		UserId:     userId,
+	}
 	result, err := useCase.Execute(input)
 	if err != nil {
 		return err
 	}
 
-	utils.WriteJSON(w, http.StatusCreated, result)
+	err = utils.WriteJSON(w, http.StatusOK, result)
+	if err != nil {
+		slog.Debug(err.Error())
+	}
 
 	return nil
 }

--- a/workout-logs/internal/core/exercise/adapter/http.go
+++ b/workout-logs/internal/core/exercise/adapter/http.go
@@ -15,50 +15,51 @@ import (
 	"time"
 )
 
-// Create Exercises Handler
+// CreateExerciseHandler Create Exercises Handler
 //
-//	@Summary		Create a couple of exercises
-//	@Tags			exercises
-//	@Accept			json
-//	@Produce		json
-//	@Param			exercises body []exercise.ExerciseRecord true "Exercises"
-//	@Success		200	{object}	any
-//	@Router			/exercises [post]
-//func CreateExerciseHandler(w http.ResponseWriter, r *http.Request) error {
-//	var input []exercise.ExerciseRecord
-//	if err := utils.ParseJson(r, &input); err != nil {
-//		return s.NewServiceError(400, err)
-//	}
-//
-//	for _, data := range input {
-//		if err := utils.ValidateJsonStruct(&data); err != nil {
-//			return s.NewServiceError(400, err)
-//		}
-//	}
-//
-//	useCase := usecases.NewCreateExercises(getExerciseRepository())
-//
-//	result, err := useCase.Execute(input)
-//	if err != nil {
-//		return err
-//	}
-//
-//	utils.WriteJSON(w, http.StatusCreated, result)
-//
-//	return nil
-//}
+//	@Summary	Create a couple of exercises
+//	@Tags		exercises
+//	@Accept		json
+//	@Produce	json
+//	@Param		exercises	body		[]exercise.ExerciseRecord	true	"Exercises"
+//	@Success	200			{object}	any
+//	@Router		/exercises [post]
+func CreateExerciseHandler(w http.ResponseWriter, r *http.Request) error {
+	var input []exercise.ExerciseRecord
+	if err := utils.ParseJson(r, &input); err != nil {
+		return s.NewServiceError(400, err)
+	}
+
+	for _, data := range input {
+		if err := utils.ValidateJsonStruct(&data); err != nil {
+			return s.NewServiceError(400, err)
+		}
+	}
+
+	useCase := usecases.NewCreateExercises(getExerciseRepository())
+
+	result, err := useCase.Execute(input)
+	if err != nil {
+		return err
+	}
+
+	utils.WriteJSON(w, http.StatusCreated, result)
+
+	return nil
+}
 
 // GetExercisesHandler handles fetching exercises based on query parameters.
 //
-// @Summary      Get exercises based on query parameters
-// @Tags         exercises
-// @Accept       json
-// @Produce      json
-// @Param        started_at query uint64 true "Start time"
-// @Param        finished_at query uint64 true "Finish time"
-// @Param        origin_id query string true "Origin ID"
-// @Param        user_id query uint64 true "User ID"
-// @Success      200 {object} any
+//	@Summary	Get exercises based on query parameters
+//	@Tags		exercises
+//	@Accept		json
+//	@Produce	json
+//	@Param		started_at	query		uint64	true	"Start time in Unix timestamp"
+//	@Param		finished_at	query		uint64	true	"Finish time in Unix timestamp"
+//	@Param		origin_id	path		string	true	"Origin ID"
+//	@Param		user_id		path		uint64	true	"User ID"
+//	@Success	200			{object}	any
+//	@Router		/users/{user_id}/origins/{origin_id}/exercises [get]
 func GetExercisesHandler(w http.ResponseWriter, r *http.Request) error {
 	startedAt, err := strconv.ParseInt(r.URL.Query().Get("started_at"), 10, 64)
 	finishedAt, err := strconv.ParseInt(r.URL.Query().Get("finished_at"), 10, 64)

--- a/workout-logs/internal/core/exercise/repository.go
+++ b/workout-logs/internal/core/exercise/repository.go
@@ -1,9 +1,10 @@
 package exercise
 
 import (
-	"context"
-
 	db "cloud-gym/internal/mongo"
+	"context"
+	"go.mongodb.org/mongo-driver/bson"
+	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -12,6 +13,7 @@ import (
 // Interface
 type ExerciseRepository interface {
 	CreateExercises(exercises []ExerciseRecord) ([]string, error)
+	GetExercises(startedAt primitive.DateTime, finishedAt primitive.DateTime, originId string, userId uint64) ([]OutputGetExercises, error)
 }
 
 // Implementation
@@ -46,4 +48,43 @@ func (r *MongoExerciseRepository) CreateExercises(exercises []ExerciseRecord) ([
 	}
 
 	return objectIds, nil
+}
+
+func (r *MongoExerciseRepository) GetExercises(startedAt primitive.DateTime, finishedAt primitive.DateTime, originId string, userId uint64) ([]OutputGetExercises, error) {
+	coll := r.client.Database(db.DATABASE_NAME).Collection(db.EXERCISES_COLLECTION_NAME)
+	filter := bson.M{
+		"started_at":  bson.M{"$gte": startedAt},
+		"finished_at": bson.M{"$lte": finishedAt},
+		"origin_id":   originId,
+		"user_id":     userId,
+	}
+
+	cursor, err := coll.Find(context.TODO(), filter)
+	if err != nil {
+		return nil, err
+	}
+	defer func(cursor *mongo.Cursor, ctx context.Context) {
+		err := cursor.Close(ctx)
+		if err != nil {
+			slog.Debug("Error closing cursor", err)
+		}
+	}(cursor, context.TODO())
+
+	var output []OutputGetExercises
+	if err = cursor.All(context.TODO(), &output); err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+type OutputGetExercises struct {
+	StartedAt  primitive.DateTime `bson:"started_at"`
+	FinishedAt primitive.DateTime `bson:"finished_at"`
+	OriginID   string             `bson:"origin_id"`
+	UserID     uint64             `bson:"user_id"`
+	Data       struct {
+		Weight uint32 `bson:"weight"`
+	}
+	ID primitive.ObjectID `bson:"_id"`
 }

--- a/workout-logs/internal/core/exercise/repository.go
+++ b/workout-logs/internal/core/exercise/repository.go
@@ -4,6 +4,7 @@ import (
 	db "cloud-gym/internal/mongo"
 	"context"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"log/slog"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -59,7 +60,8 @@ func (r *MongoExerciseRepository) GetExercises(startedAt primitive.DateTime, fin
 		"user_id":     userId,
 	}
 
-	cursor, err := coll.Find(context.TODO(), filter)
+	opts := options.Find().SetSort(bson.D{{"started_at", 1}})
+	cursor, err := coll.Find(context.TODO(), filter, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -79,12 +81,12 @@ func (r *MongoExerciseRepository) GetExercises(startedAt primitive.DateTime, fin
 }
 
 type OutputGetExercises struct {
-	StartedAt  primitive.DateTime `bson:"started_at"`
-	FinishedAt primitive.DateTime `bson:"finished_at"`
-	OriginID   string             `bson:"origin_id"`
-	UserID     uint64             `bson:"user_id"`
+	StartedAt  primitive.DateTime `bson:"started_at" json:"started_at"`
+	FinishedAt primitive.DateTime `bson:"finished_at" json:"finished_at"`
+	OriginID   string             `bson:"origin_id" json:"origin_id"`
+	UserID     uint64             `bson:"user_id" json:"user_id"`
 	Data       struct {
-		Weight uint32 `bson:"weight"`
-	}
-	ID primitive.ObjectID `bson:"_id"`
+		Weight uint32 `bson:"weight" json:"weight"`
+	} `bson:"data" json:"data"`
+	ID primitive.ObjectID `bson:"_id" json:"id"`
 }

--- a/workout-logs/internal/core/exercise/usecases/get_exercises.go
+++ b/workout-logs/internal/core/exercise/usecases/get_exercises.go
@@ -1,0 +1,27 @@
+package usecases
+
+import (
+	"cloud-gym/internal/core/exercise"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type InputGetExercises struct {
+	StartedAt  primitive.DateTime
+	FinishedAt primitive.DateTime
+	OriginId   string
+	UserId     uint64
+}
+
+type GetExercises struct {
+	exerciseRepository exercise.ExerciseRepository
+}
+
+func NewGetExercises(exerciseRepository exercise.ExerciseRepository) GetExercises {
+	return GetExercises{
+		exerciseRepository: exerciseRepository,
+	}
+}
+
+func (g *GetExercises) Execute(input InputGetExercises) ([]exercise.OutputGetExercises, error) {
+	return g.exerciseRepository.GetExercises(input.StartedAt, input.FinishedAt, input.OriginId, input.UserId)
+}


### PR DESCRIPTION
This pull request introduces a new feature that adds an endpoint to fetch exercises based on query parameters. It includes updates to the Swagger documentation, the HTTP router, and the exercise repository and handler.

### New Feature: Fetch Exercises Endpoint

* [`workout-logs/internal/adapter/http.go`](diffhunk://#diff-8f0779e8a6da32c1972fd2c8c44ff95b8a22a8bc3e3774b2de00aebd581e1d9aL14-R14): Added a new route to handle GET requests for fetching exercises based on query parameters.
* [`workout-logs/internal/core/exercise/adapter/http.go`](diffhunk://#diff-862ab18e7502f42edb1a0b2b73e4fad737c451dd1cfd283b10c1acbeeb36d59dR51-R102): Implemented `GetExercisesHandler` to process incoming requests and retrieve exercises from the database.
* [`workout-logs/internal/core/exercise/repository.go`](diffhunk://#diff-a49d91384bf9c2a3b2933e9a1aad52ac1db24fd6d8b28d0cf184d7b952b1c3f6R53-R92): Added `GetExercises` method to the `MongoExerciseRepository` to query exercises based on the specified parameters.
* [`workout-logs/internal/core/exercise/usecases/get_exercises.go`](diffhunk://#diff-67b047401f255df958e6a879c144261404ce826017a686481fba79c456f28613R1-R27): Introduced a new use case `GetExercises` to encapsulate the logic for fetching exercises.

### Documentation Updates

* `workout-logs/docs/docs.go`, `workout-logs/docs/swagger.json`, `workout-logs/docs/swagger.yaml`: Updated Swagger documentation to include the new endpoint for fetching exercises and removed hardcoded API metadata. [[1]](diffhunk://#diff-547aaf3d6cde0735fd7bca2b6d64b6298d00d43db794f673500683de1d9f9a2cR51-R100) [[2]](diffhunk://#diff-a9f3c21fad8a4ef0599cca718934a33f9793838781219a0600abb032502ceff4R40-R89) [[3]](diffhunk://#diff-41ae1d3055b451cf787943b20d93ea7204cc3ec0c7357f6970a749115fd8375eR55-R88)

### Build System

* [`workout-logs/Makefile`](diffhunk://#diff-851a01b25a74112b26ea65421db07f58f5f96d715c1858871bc01136047d4e55R24-R27): Added a new `docs` target to generate Swagger documentation.